### PR TITLE
feat: 支持双语图表标题显示及诚信承诺页

### DIFF
--- a/doc.md
+++ b/doc.md
@@ -1,0 +1,40 @@
+## 双语图片标题使用说明
+
+本模板支持两种图片标题格式：普通图片标题和双语图片标题。需要注意的是，目前这两种格式**不能同时使用**，请根据需求选择其中一种。
+
+### 1. 普通图片标题
+
+使用 Typst 原生的 `figure` 语法:
+
+```typst
+#figure(
+  placement: top,  // 控制图片位置
+  caption: [图片标题],
+)[
+  #image("path/to/image.png", width: 80%)
+] <fig:label>
+```
+
+### 2. 双语图片标题
+
+使用模板提供的 `bilingual-figure` 函数:
+
+```typst
+#bilingual-figure(
+  image("path/to/image.png", width: 80%),
+  caption: "中文标题",
+  caption-en: "English Caption",
+  manual-number: "1.1"  // 需要手动指定编号
+)
+```
+
+### ⚠️ 注意事项
+
+1. 两种格式不能混用，否则会导致图片编号出现问题
+2. 使用双语图片标题时，需要手动维护 `manual-number` 参数以确保编号的正确性
+3. 目前双语图片标题不支持引用功能
+
+### 选择建议
+
+- 如果论文全程只需要单语言标题，建议使用普通图片标题格式
+- 如果需要中英双语标题，则使用 `bilingual-figure`，但需要手动管理编号

--- a/layouts/mainmatter.typ
+++ b/layouts/mainmatter.typ
@@ -121,13 +121,23 @@
   show figure.caption: set text(size: caption-size, font: fonts.楷体)
   show figure.caption: set par(leading: 1em)
 
+  /*
+   * Uncomment this to show the caption with supplement and numbering
+   */
+  // show figure.caption: c => block(inset: (top: figure-caption-spacing, bottom: figure-caption-spacing))[
+  //   #set align(left)
+  //   #text(font: fonts.宋体, weight: "regular", style: "normal")[
+  //     #c.supplement #context c.counter.display(c.numbering)
+  //     ]
+  //     #h(0.3em)#c.body
+  // ]
+
   show figure.caption: c => block(inset: (top: figure-caption-spacing, bottom: figure-caption-spacing))[
     #set align(left)
-    #text(font: fonts.黑体, weight: "regular", style: "normal")[
-      #c.supplement #context c.counter.display(c.numbering)
-      ]
-      #h(0.3em)#c.body
+    // 只显示caption内容，不显示supplement和numbering
+    #c.body
   ]
+  
   show figure.where(placement: none): it => {
     v(figure-clearance / 6)
     it

--- a/pages/bachelor-academic-integrity.typ
+++ b/pages/bachelor-academic-integrity.typ
@@ -1,0 +1,82 @@
+#import "../utils/style.typ": 字号, 字体
+#import "../utils/indent.typ": indent
+
+#let bachelor-academic-integrity(twoside: false, fonts: (:), info: (:), anonymous: false) = {
+
+  fonts = 字体 + fonts
+  info = (
+    title: ("基于 Typst 的", "华东师范大学学位论文"),
+  ) + info
+
+
+  if type(info.title) == str {
+    info.title = info.title.split("\n")
+  }
+
+  pagebreak(weak: true, to: if twoside { "odd" })
+
+  v(6pt)
+
+  // 第一部分：诚信承诺
+  align(
+    center,
+    text(
+      font: fonts.宋体,
+      size: 字号.四号, 
+      weight: "bold",
+      "华东师范大学学位论文诚信承诺",
+    ),
+  )
+
+  v(16pt) 
+
+  block[
+    #set text(font: fonts.宋体, size: 字号.小四) 
+    #set par(justify: true, first-line-indent: 2em, leading: 1.5em)
+
+    #indent 本毕业论文是本人在导师指导下独立完成的，内容真实、可靠。本人在撰写毕业论文过程中不存在请人代写、抄袭或者剽窃他人作品、伪造或者篡改数据以及其他学位论文作假行为。
+
+    本人清楚知道学位论文作假行为将会导致行为人受到不授予/撤销学位、开除学籍等处理（处分）决定。本人如果被查证在撰写本毕业论文过程中存在学位论文作假行为，愿意接受学校依法作出的处理（处分）决定。
+  ]
+
+  v(36pt)
+
+  align(right)[
+    #set text(font: fonts.宋体, size: 字号.小四)
+    承诺人签名：#h(12em)日期：#h(4em)年#h(2em)月#h(2em)日
+  ]
+
+  v(56pt) 
+
+  // 第二部分：使用授权说明
+  align(
+    center,
+    text(
+      font: fonts.宋体, 
+      size: 字号.四号,
+      weight: "bold",
+      "华东师范大学学位论文使用授权说明",
+    ),
+  )
+
+  v(16pt)
+
+  block[
+    #set text(font: fonts.宋体, size: 字号.小四)
+    #set par(justify: true, first-line-indent: 2em, leading: 1.5em)
+
+    #indent 本论文的研究成果归华东师范大学所有，本论文的研究内容不得以其它单位的名义发表。本学位论文作者和指导教师完全了解华东师范大学有关保留、使用学位论文的规定，即：学校有权保留并向国家有关部门或机构送交论文的复印件和电子版，允许论文被查阅和借阅；本人授权华东师范大学可以将论文的全部或部分内容编入有关数据库进行检索、交流，可以采用影印、缩印或其他复制手段保存论文和汇编本学位论文。
+
+    保密的毕业论文（设计）在解密后应遵守此规定。
+  ]
+
+  v(42pt)
+  align(right)[
+    #set text(font: fonts.宋体, size: 字号.小四)
+    作者签名：#h(4em)导师签名：#h(4em)日期：#h(4em)年#h(2em)月#h(2em)日
+  ]
+
+  if twoside {
+    pagebreak() + " "
+  }
+}

--- a/template/thesis.typ
+++ b/template/thesis.typ
@@ -1,4 +1,5 @@
 #import "@preview/modern-ecnu-thesis:0.2.0": documentclass, indent, no-indent, word-count-cjk, total-words
+#import "../utils/bilingual-figure.typ": *
 
 // 模板用到的主要字体：https://github.com/jtchen2k/modern-ecnu-thesis/tree/main/fonts/
 // 如果是在 Web App 上编辑，你应该手动上传上述字体文件，否则不能正常使用「楷体」和「仿宋」。
@@ -179,6 +180,14 @@
 )[
   #image("images/ecnu-emblem.svg", width: 20%)
 ] <ecnu-logo>
+
+
+#bilingual-figure(
+  image("images/ecnu-emblem.svg", width: 20%),
+  caption: "双语图片标题",
+  caption-en: "Bilingual Figure Caption",
+  manual-number: "1.1" // need manual numbering
+) 
 
 == 数学公式
 

--- a/utils/bilingual-figure.typ
+++ b/utils/bilingual-figure.typ
@@ -1,0 +1,54 @@
+#import "../utils/style.typ": 字号, 字体
+
+// 中英双语图片标题函数（支持手动编号）
+#let bilingual-figure(
+  body,
+  caption: none,
+  caption-en: none,
+  kind: "figure",
+  supplement: auto,
+  numbering: "1.1",
+  gap: 0.65em,
+  manual-number: none,
+) = context {
+  let sup = if supplement == auto {
+    if kind == "figure" { "图" }
+    else if kind == "table" { "表" }
+    else { kind }
+  } else { supplement }
+  
+  let sup-en = if supplement == auto {
+    if kind == "figure" { "Figure" }
+    else if kind == "table" { "Table" }
+    else { kind }
+  } else { supplement }
+  
+  let display-number = if manual-number != none {
+    manual-number
+  } else {
+    counter(kind).display(numbering)
+  }
+  
+  figure(
+    body,
+    caption: if caption != none {
+      [
+        #set text(font: 字体.宋体, size: 字号.小四, weight: "regular")
+        #set align(center)
+        #sup #display-number #caption
+        
+        #if caption-en != none {
+          [
+            #set text(font: 字体.宋体, size: 字号.五号, weight: "regular")
+            #set align(center)
+            #sup-en #display-number #caption-en
+          ]
+        }
+      ]
+    },
+    kind: kind,
+    gap: gap,
+    supplement: "", 
+    numbering: none,
+  )
+}


### PR DESCRIPTION
💡 新增功能：支持通过 bilingual-figure 自定义函数插入中英双语图表标题

 *  接受参数：中文标题 caption、英文标题 caption-en、手动编号 manual-number

📚 文档更新：新增双语图片标题使用说明

📑 其他补充：增加 academic integrity 页面内容