### PR TITLE
增加了本科生声明页，同时修改了宋体的选择优先级

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ template/*.pdf
 package.json
 Makefile
 .DS_Store
+.vs

--- a/lib.typ
+++ b/lib.typ
@@ -183,7 +183,14 @@
       } else if doctype == "postdoc" {
         panic("postdoc has not yet been implemented.")
       } else if doctype == "bachelor" {
-        panic-page("declaration page has not yet been implemented for bachelors.")
+        // panic-page("declaration page has not yet been implemented for bachelors.")
+        bachelor-decl-page(
+          anonymous: anonymous,
+          twoside: twoside,
+          ..args,
+          fonts: fonts + args.named().at("fonts", default: (:)),
+          info: info + args.named().at("info", default: (:)),
+        )
       }
     },
     // 诚信承诺页，通过 type 分发到不同函数

--- a/pages/bachelor-decl-page.typ
+++ b/pages/bachelor-decl-page.typ
@@ -1,72 +1,68 @@
 #import "../utils/indent.typ": indent
 #import "../utils/style.typ": 字号, 字体
+#import "../utils/str.typ": to-normal-str
 
 // 本科生声明页
-#let bachelor-decl-page(
-  anonymous: false,
-  twoside: false,
-  fonts: (:),
-  info: (:),
-) = {
-  // 0. 如果需要匿名则短路返回
-  if anonymous {
-    return
-  }
+#let bachelor-decl-page(anonymous: false, twoside: false, fonts: (:), info: (:), doctype: "bachelor") = {
 
   // 1.  默认参数
   fonts = 字体 + fonts
-  info = (
-    title: ("基于 Typst 的", "华东师范大学学位论文"),
-  ) + info
 
-  // 2.  对参数进行处理
-  // 2.1 如果是字符串，则使用换行符将标题分隔为列表
-  if type(info.title) == str {
-    info.title = info.title.split("\n")
-  }
+  // 2. 处理标题
+  let title = to-normal-str(src: info.title)
 
+  // 3. 正式渲染。
+  pagebreak(weak: true)
 
-  // 3.  正式渲染
-  pagebreak(weak: true, to: if twoside { "odd" })
+   v(12pt)
 
-  v(6pt)
+  align(center, text(font: fonts.宋体, size: 字号.四号, weight: "bold", "华东师范大学学位论文原创性声明"))
 
-  align(center, image("../assets/ecnu-emblem.svg", width: 1.95cm))
-
-  v(-12pt)
-
-  align(
-    center,
-    text(
-      font: fonts.黑体,
-      size: 字号.小一,
-      weight: "bold",
-      "华东师范大学本科毕业论文（设计）\n诚信承诺书",
-    ),
-  )
-
-  v(48pt)
+  // v(12pt)
 
   block[
-    #set text(font: fonts.宋体, size: 字号.小三)
-    #set par(justify: true, first-line-indent: 2em, leading: 2.42em)
+    #set text(font: fonts.宋体, size: 11.5pt, weight: "regular")
+    #set par(justify: true, first-line-indent: 2em, leading: 1em)
 
-    #indent 本人郑重承诺：所呈交的毕业论文（设计）（题目：#info.title.sum()）是在指导教师的指导下严格按照学校和院系有关规定由本人独立完成的。本毕业论文（设计）中引用他人观点及参考资源的内容均已标注引用，如出现侵犯他人知识产权的行为，由本人承担相应法律责任。本人承诺不存在抄袭、伪造、篡改、代写、买卖毕业论文（设计）等违纪行为。
+    #indent 本毕业论文是本人在导师指导下独立完成的，内容真实、可靠。本人在撰写毕业论文过程中不存在请人代写、抄袭或者剽窃他人作品、伪造或者篡改数据以及其他学位论文作假行为。
+
+    本人清楚知道学位论文作假行为将会导致行为人受到不授予/撤销学位、开除学籍等处理（处分）决定。本人如果被查证在撰写本毕业论文过程中存在学位论文作假行为，愿意接受学校依法作出的处理（处分）决定。
+
+
+    #v(1.5em)
+
+    #block(inset: (left: 2em), grid(columns: (1fr, 1fr), [承诺人签名：], [#h(3.5em)日期：#h(2.5em)年#h(2em)月#h(2em)日]))
   ]
 
-  v(76pt)
+  v(36pt)
 
-  grid(
-    columns: (1fr, 150pt),
-    [],
-    align(left)[
-      #set text(font: fonts.黑体, size: 字号.小三)
+  align(center, text(font: fonts.宋体, size: 字号.四号, weight: "bold", "华东师范大学学位论文使用授权说明 "))
 
-      作者签名：
 
-      学号：
 
-      日期：
-    ]
-  )
+  block[
+    #set text(font: fonts.宋体, size: 11.5pt)
+    #set par(justify: true, first-line-indent: 2em, leading: 1em)
+
+    #indent 本论文的研究成果归华东师范大学所有，本论文的研究内容不得以其它单位的名义发表。本学位论文作者和指导教师完全了解华东师范大学有关保留、使用学位论文的规定，即：学校有权保留并向国家有关部门或机构送交论文的复印件和电子版，允许论文被查阅和借阅；本人授权华东师范大学可以将论文的全部或部分内容编入有关数据库进行检索、交流，可以采用影印、缩印或其他复制手段保存论文和汇编本学位论文。
+
+保密的毕业论文（设计）在解密后应遵守此规定。
+#v(12pt)
+
+
+
+    #v(1em)
+
+    #block(inset: (left: 2em), 
+     [导师签名：#h(5em)作者签名：#h(6em)日期：#h(2em)年#h(1.5em)月#h(1.5em)日])
+
+    #v(3em)
+
+
+
+  ]
+
+  if twoside {
+    pagebreak() + " "
+  }
 }

--- a/pages/bachelor-decl-page.typ
+++ b/pages/bachelor-decl-page.typ
@@ -16,7 +16,7 @@
 
    v(12pt)
 
-  align(center, text(font: fonts.宋体, size: 字号.四号, weight: "bold", "华东师范大学学位论文原创性声明"))
+  align(center, text(font: fonts.宋体, size: 字号.四号, weight: "bold", "华东师范大学学位论文诚信承诺"))
 
   // v(12pt)
 
@@ -25,6 +25,7 @@
     #set par(justify: true, first-line-indent: 2em, leading: 1em)
 
     #indent 本毕业论文是本人在导师指导下独立完成的，内容真实、可靠。本人在撰写毕业论文过程中不存在请人代写、抄袭或者剽窃他人作品、伪造或者篡改数据以及其他学位论文作假行为。
+    
     本人清楚知道学位论文作假行为将会导致行为人受到不授予/撤销学位、开除学籍等处理（处分）决定。本人如果被查证在撰写本毕业论文过程中存在学位论文作假行为，愿意接受学校依法作出的处理（处分）决定。
 
 

--- a/pages/bachelor-decl-page.typ
+++ b/pages/bachelor-decl-page.typ
@@ -25,16 +25,14 @@
     #set par(justify: true, first-line-indent: 2em, leading: 1em)
 
     #indent 本毕业论文是本人在导师指导下独立完成的，内容真实、可靠。本人在撰写毕业论文过程中不存在请人代写、抄袭或者剽窃他人作品、伪造或者篡改数据以及其他学位论文作假行为。
-
     本人清楚知道学位论文作假行为将会导致行为人受到不授予/撤销学位、开除学籍等处理（处分）决定。本人如果被查证在撰写本毕业论文过程中存在学位论文作假行为，愿意接受学校依法作出的处理（处分）决定。
 
 
-    #v(1.5em)
 
-    #block(inset: (left: 2em), grid(columns: (1fr, 1fr), [承诺人签名：], [#h(3.5em)日期：#h(2.5em)年#h(2em)月#h(2em)日]))
-  ]
 
-  v(36pt)
+    #block(inset: (left: 2em), grid(columns: (1fr, 1fr), [承诺人签名：], [#h(3.5em)日期：#h(2.5em)年#h(2em)月#h(2em)日]))]
+
+  v(4.5em)
 
   align(center, text(font: fonts.宋体, size: 字号.四号, weight: "bold", "华东师范大学学位论文使用授权说明 "))
 

--- a/utils/style.typ
+++ b/utils/style.typ
@@ -50,7 +50,6 @@
   仿宋: ("Times New Roman", "FangSong", "FangSong SC", "STFangSong", "FZFangSong-Z02S", "Noto Serif CJK SC"),
   // 等宽字体，用于代码块环境，一般可以等同于英文中的 Monospaced Font
   等宽: ("Inconsolata", "Courier New", "Menlo", "IBM Plex Mono", "Source Han Sans HW SC", "Source Han Sans HW", "Noto Sans Mono CJK SC", "SimHei", "Heiti SC", "STHeiti"),
-  NotoSerif: ("Source Han Serif"),
 )
 
 #let fonts = (
@@ -59,5 +58,4 @@
   kai: 字体.楷体,
   fang: 字体.仿宋,
   mono: 字体.等宽,
-  noto: 字体.NotoSerif,
 )

--- a/utils/style.typ
+++ b/utils/style.typ
@@ -41,7 +41,7 @@
 
 #let 字体 = (
   // 宋体，属于「有衬线字体」，一般可以等同于英文中的 Serif Font
-  宋体: ("Times New Roman", "Songti SC", "STSongti", "Source Han Serif CN", "Source Han Serif", "Noto Serif CJK SC", "SimSun"),
+  宋体: ("Times New Roman", "Source Han Serif", "Source Han Serif CN","Songti SC", "STSongti",  "Noto Serif CJK SC", "SimSun"),
   // 黑体，属于「无衬线字体」，一般可以等同于英文中的 Sans Serif Font
   黑体: ("Helvetica", "Arial", "Heiti SC", "STHeiti", "SimHei", "Source Han Sans SC", "Source Han Sans", "Noto Sans CJK SC"),
   // 楷体
@@ -50,6 +50,7 @@
   仿宋: ("Times New Roman", "FangSong", "FangSong SC", "STFangSong", "FZFangSong-Z02S", "Noto Serif CJK SC"),
   // 等宽字体，用于代码块环境，一般可以等同于英文中的 Monospaced Font
   等宽: ("Inconsolata", "Courier New", "Menlo", "IBM Plex Mono", "Source Han Sans HW SC", "Source Han Sans HW", "Noto Sans Mono CJK SC", "SimHei", "Heiti SC", "STHeiti"),
+  NotoSerif: ("Source Han Serif"),
 )
 
 #let fonts = (
@@ -58,4 +59,5 @@
   kai: 字体.楷体,
   fang: 字体.仿宋,
   mono: 字体.等宽,
+  noto: 字体.NotoSerif,
 )


### PR DESCRIPTION
参考我们院系发下来的毕业论文模板增加了本科生声明页，同时由于前几个宋体字体我去网上下载下来并不支持修改字重，所以将Source Han Serif调整成了第一选择。下面是我们院系的毕业论文模板，可以校对一下再merge进去。
[毕业论文模板理科.docx](https://github.com/user-attachments/files/19652573/default.docx)
